### PR TITLE
Only initialize module once.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "droptica/codeception-drupal-bootstrap",
+    "name": "codeception/module-drupal",
     "description": "A module for Codeception that exposes the Drupal API to test suites.",
     "license": "MIT",
     "authors": [

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "codeception/codeception": "2.*"
+        "codeception/codeception": "*"
     },
     "autoload": {
         "psr-4": {
@@ -33,7 +33,7 @@
     "require-dev": {
         "squizlabs/php_codesniffer": "2.1.0",
         "satooshi/php-coveralls": "dev-master",
-        "mikey179/vfsStream": "1.4.*",
+        "mikey179/vfsstream": "1.4.*",
         "phpspec/prophecy": "~1.3@dev"
     },
     "repositories": [

--- a/src/Module/Drupal7/Drupal7.php
+++ b/src/Module/Drupal7/Drupal7.php
@@ -18,15 +18,17 @@ class Drupal7 extends DrupalBaseModule implements DrupalModuleInterface
     use Asserts;
     use EntityTrait;
     use FieldTrait;
+    protected $initialized;
 
-    /**
+  /**
      * { @inheritdoc }
      */
     public function _initialize()
     {
-
-        $this->bootstrapDrupal();
-
+        if (!$this->initialized) {
+          $this->bootstrapDrupal();
+          $this->initialized = TRUE;
+        }
     }
 
     /**


### PR DESCRIPTION
Should prevent issues with redeclaring constants (like `Constant REQUEST_TIME already defined`) and re-including files when running the module in multiple suites (functional & acceptance for instance).
